### PR TITLE
observe with onValueChange closure

### DIFF
--- a/Continuum.xcodeproj/project.pbxproj
+++ b/Continuum.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F95662A2042681800039EB2 /* OnValueChangeClosureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9566292042681800039EB2 /* OnValueChangeClosureTests.swift */; };
 		3700DEE0202A17630010408B /* PThreadMutex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3700DEDF202A17630010408B /* PThreadMutex.swift */; };
 		379BCD192029FF9600450632 /* Continuum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 379BCD0F2029FF9600450632 /* Continuum.framework */; };
 		379BCD1E2029FF9600450632 /* ContinuumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 379BCD1D2029FF9600450632 /* ContinuumTests.swift */; };
@@ -31,6 +32,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1F9566292042681800039EB2 /* OnValueChangeClosureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnValueChangeClosureTests.swift; sourceTree = "<group>"; };
 		3700DEDF202A17630010408B /* PThreadMutex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PThreadMutex.swift; sourceTree = "<group>"; };
 		379BCD0F2029FF9600450632 /* Continuum.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Continuum.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		379BCD122029FF9600450632 /* Continuum.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Continuum.h; sourceTree = "<group>"; };
@@ -105,6 +107,7 @@
 				379BCD1F2029FF9600450632 /* Info.plist */,
 				9DF34AC1202C490A00809EF1 /* VariableTests.swift */,
 				9DF34AC3202C493B00809EF1 /* ConstantTests.swift */,
+				1F9566292042681800039EB2 /* OnValueChangeClosureTests.swift */,
 			);
 			path = ContinuumTests;
 			sourceTree = "<group>";
@@ -244,6 +247,7 @@
 			files = (
 				379BCD1E2029FF9600450632 /* ContinuumTests.swift in Sources */,
 				9DF34AC4202C493B00809EF1 /* ConstantTests.swift in Sources */,
+				1F95662A2042681800039EB2 /* OnValueChangeClosureTests.swift in Sources */,
 				9DF34AC2202C490A00809EF1 /* VariableTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Continuum/Continuum.swift
+++ b/Continuum/Continuum.swift
@@ -233,6 +233,18 @@ extension NotificationCenterContinuum {
     ///
     /// - parameter source: Observed object.
     /// - parameter queue: Binding execution qeueue.
+    /// - parameter onValueChange: Value handler.
+    /// - returns: Observer that observes a object that confirms ValueRepresentable.
+    public func observe<S: ValueRepresentable, V>(_ source: S,
+                                                  on queue: OperationQueue? = nil,
+                                                  onValueChange: @escaping (V) -> ()) -> Observer where S.E == V {
+        return _observe(source, on: queue, onValueChange: onValueChange)
+    }
+
+    /// Binds source.value to property of target object.
+    ///
+    /// - parameter source: Observed object.
+    /// - parameter queue: Binding execution qeueue.
     /// - parameter target: Binding target.
     /// - parameter keyPath: KeyPath for target that confirms Wrappable.
     /// - returns: Observer that observes a ValueRepresentable.
@@ -302,14 +314,14 @@ extension NotificationCenterContinuum {
     }
 
     private func _observe<S: ValueRepresentable, T: AnyObject, V>(_ source: S,
-                                                                    on queue: OperationQueue? = nil,
-                                                                    bindTo target: T,
-                                                                    _ keyPath: ReferenceWritableKeyPath<T, V>) -> Observer {
+                                                                  on queue: OperationQueue? = nil,
+                                                                  bindTo target: T,
+                                                                  _ keyPath: ReferenceWritableKeyPath<T, V>) -> Observer {
         let handler: () -> () = { [weak source, weak target] in
             guard
                 let target = target,
                 let value = source?.value as? V
-            else { return }
+                else { return }
             target[keyPath: keyPath] = value
         }
 
@@ -318,4 +330,25 @@ extension NotificationCenterContinuum {
         let observer = center.addObserver(forName: source.uniqueName, object: nil, queue: queue) { _ in handler() }
         return Observer(rawObserver: observer, center: center)
     }
+
+    private func _observe<S: ValueRepresentable, V>(_ source: S,
+                                                    on queue: OperationQueue? = nil,
+                                                    onValueChange: @escaping (V) -> ()) -> Observer where S.E == V {
+        let handler: () -> () = { [weak source] in
+            guard let value = source?.value else { return }
+            onValueChange(value)
+        }
+
+        if let _queue = queue, OperationQueue.current != _queue {
+            // only dispatch async if given queue is different from current
+            _queue.addOperation(handler)
+        } else {
+            handler()
+        }
+
+        (source as? NotificationCenterSettable)?.setCenter(center)
+        let observer = center.addObserver(forName: source.uniqueName, object: nil, queue: queue) { _ in handler() }
+        return Observer(rawObserver: observer, center: center)
+    }
+
 }

--- a/Continuum/Continuum.swift
+++ b/Continuum/Continuum.swift
@@ -325,7 +325,9 @@ extension NotificationCenterContinuum {
             target[keyPath: keyPath] = value
         }
 
+        // FIXME: need to dispatch on given queue if it's non-nil and different from current queue.
         handler()
+
         (source as? NotificationCenterSettable)?.setCenter(center)
         let observer = center.addObserver(forName: source.uniqueName, object: nil, queue: queue) { _ in handler() }
         return Observer(rawObserver: observer, center: center)

--- a/ContinuumTests/OnValueChangeClosureTests.swift
+++ b/ContinuumTests/OnValueChangeClosureTests.swift
@@ -1,0 +1,103 @@
+//
+//  OnValueChangeClosureTests.swift
+//  ContinuumTests
+//
+//  Created by Toshihiro Suzuki on 2018/02/25.
+//  Copyright © 2018 marty-suzuki. All rights reserved.
+//
+
+import XCTest
+@testable import Continuum
+
+final class OnValueChangeClosureTests: XCTestCase {
+    private class Cat {
+        var sound = "Meow"
+    }
+
+    private var _barkOfDog: Variable<String>!
+    private var barkOfDog: Constant<String>!
+    private var cat: Cat!
+
+    override func setUp() {
+        super.setUp()
+
+        _barkOfDog = Variable(value: "Bow wow")
+        barkOfDog = Constant(variable: _barkOfDog)
+        cat = Cat()
+    }
+
+    func testBindingWithNoQueue() {
+
+        XCTAssertEqual(cat.sound, "Meow")
+
+        let center = NotificationCenter()
+        _ = center.continuum.observe(barkOfDog, onValueChange: { [unowned self] barkOfDog in
+            XCTAssertTrue(Thread.isMainThread)
+            self.cat.sound = barkOfDog
+        })
+
+        // NOTE: No need to setup XCTestExpectation.
+        //   Continuum is on main thread all the time in this case.
+
+        XCTAssertEqual(cat.sound, "Bow wow")
+
+        _barkOfDog.value = "Meow"
+
+        XCTAssertEqual(cat.sound, "Meow")
+    }
+
+    func testBindingWithMainQueue() {
+
+        XCTAssertEqual(cat.sound, "Meow")
+
+        let center = NotificationCenter()
+        _ = center.continuum.observe(barkOfDog, on: .main, onValueChange: { [unowned self] barkOfDog in
+            XCTAssertTrue(Thread.isMainThread)
+            self.cat.sound = barkOfDog
+        })
+
+        // NOTE: No need to setup XCTestExpectation.
+        //   Continuum is on main thread all the time in this case, too.
+        //   Because given queue `.main` is same as the current queue.
+
+        XCTAssertEqual(cat.sound, "Bow wow")
+
+        _barkOfDog.value = "Meow"
+
+        XCTAssertEqual(cat.sound, "Meow")
+    }
+
+    func testBindingWithBackgroundQueue() {
+
+        XCTAssertEqual(cat.sound, "Meow")
+
+        let backgroundQueue = OperationQueue()
+
+        // NOTE: We need to setup XCTestExpectation.
+        //   Continuum dispatches onValueChanges handler call on given queue.
+        let ex1 = expectation(description: "first expectation")
+        let ex2 = expectation(description: "second expectation")
+        var exs = [ex1, ex2]
+
+        let center = NotificationCenter()
+        _ = center.continuum.observe(barkOfDog, on: backgroundQueue, onValueChange: { [unowned self] barkOfDog in
+
+            // Pretend as an expensive logic.
+            usleep(200 * 1000) // 0.2 sec
+
+            self.cat.sound = barkOfDog
+            XCTAssertFalse(Thread.isMainThread)
+            exs.removeFirst().fulfill()
+        })
+
+        wait(for: [ex1], timeout: 0.3)
+
+        XCTAssertEqual(cat.sound, "Bow wow")
+
+        _barkOfDog.value = "Meow"
+
+        wait(for: [ex2], timeout: 0.3)
+
+        XCTAssertEqual(cat.sound, "Meow")
+    }
+}


### PR DESCRIPTION
Added new observe method with a value handler closure.
This way user can define simple action trigger like this.
```swift
class ViewModel {
    let alertMessage: Variable<String>
}

class ViewController: UIViewController {
    override func viewDidLoad() {
        super.viewDidLoad()

        center.continuum.observe(viewModel.alertMessage, on: .main) { [weak self] msg in
            if !msg.isEmpty {
                self?.alert(msg)
            }
        }
    }
}
```

Also I added FIXME comment to where initial `handler()` call isn't dispatched on specified queue.